### PR TITLE
Allow dynamic modification of universes the server listens on

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ server.on('packet', function (packet) {
 });
 ```
 
+Universes to listen for can be added and droppped at any time by calling `addUniverse(universes)` or `dropUniverse(universes)`, respectively. The argument for these methods is an array of universe numbers.
+
 ## E1.31 (sACN) Packet Class
 
 The E1.31 Packet class contains a number of useful setter methods:

--- a/lib/server.js
+++ b/lib/server.js
@@ -80,6 +80,24 @@ Server.prototype.close = function close() {
   this._socket.close();
 };
 
+Server.prototype.addUniverses = function(universes) {
+  universes.forEach(universe => {
+    if (this.universes.includes(universe)) return;
+    this.universes.push(universe);
+    this._lastSequenceNumber[universe] = 0;
+    this._socket.addMembership(e131.getMulticastGroup(universe));
+  });
+};
+
+Server.prototype.dropUniverses = function(universes) {
+  universes.forEach(universe => {
+    if (!this.universes.includes(universe)) return;
+    this.universes.splice(this.universes.indexOf(universe), 1);
+    delete this._lastSequenceNumber[universe];
+    this._socket.dropMembership(e131.getMulticastGroup(universe));
+  });
+};
+
 // server object inherits from EventEmitter
 util.inherits(Server, EventEmitter);
 


### PR DESCRIPTION
This PR introduces `server.addUniverses(universes)` and `server.dropUniverses(universes)` methods to add and remove universes the server listens for at runtime.