### PR TITLE
Enable automatic multicasting

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -29,10 +29,6 @@ function Client(arg, port) {
     return new Client(arg, port);
   }
 
-  if (arg === undefined) {
-    throw new TypeError('arg should be a host address, name or universe');
-  }
-
   this.host = Number.isInteger(arg) ? e131.getMulticastGroup(arg) : arg;
   this.port = port || e131.DEFAULT_PORT;
   this._socket = dgram.createSocket('udp4');
@@ -46,7 +42,7 @@ Client.prototype.createPacket = function createPacket(numSlots) {
 // send E1.31 packet
 Client.prototype.send = function send(packet, callback) {
   callback = callback || function() {};
-  this._socket.send(packet.getBuffer(), this.port, this.host, function onSend() {
+  this._socket.send(packet.getBuffer(), this.port, this.host || e131.getMulticastGroup(packet.getUniverse()), function onSend() {
     packet.incrementSequenceNumber();
     callback();
   });


### PR DESCRIPTION
If the destination IP address is undefined when the client is created, then use
the universe number to determine the multicast address to send the packet to.