### PR TITLE
add multicastInterface option for specifying which interface to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,15 @@ The Client class implements a UDP client for sending E1.31 (sACN) traffic. The c
 
 ```javascript
 var e131 = require('e131');
-var client = new e131.Client(arg, [port]);
+var client = new e131.Client(arg, [port], {multicastInterface:'192.168.0.2'});
 ```
 
-The first argument can be a host address, name or universe number. If `port` is omitted, the default E1.31 port `5568` is used.
-If a universe is given, the client will automatically join the relevant Multicast group.
+The first argument can be a host address, name or universe number. If a universe is given, the client will automatically join the relevant Multicast group.
+
+If `port` is omitted, the default E1.31 port `5568` is used.
+
+If you have multiple network interface you can use `multicastInterface` option to specify which one to use. The value should be the ip address of the outgoing network interface, for example `192.168.0.2`.
+
 The client automatically increments (and wraps around if necessary) the sequence number of the transmitted packet.
 
 The client provides two methods:
@@ -87,6 +91,26 @@ var e131 = require('e131');
 var server = new e131.Server([0x0001, 0x0002]);
 server.on('listening', function() {
   console.log('server listening on port %d, universes %j', this.port, this.universes);
+});
+server.on('packet', function (packet) {
+  var sourceName = packet.getSourceName();
+  var sequenceNumber = packet.getSequenceNumber();
+  var universe = packet.getUniverse();
+  var slotsData = packet.getSlotsData();
+
+  console.log('source="%s", seq=%d, universe=%d, slots=%d',
+    sourceName, sequenceNumber, universe, slotsData.length);
+  console.log('slots data = %s', slotsData.toString('hex'));
+});
+```
+
+If you have multiple network interfaces you can specify which interface to use with the multicastInterface option
+```javascript
+var e131 = require('e131');
+
+var server = new e131.Server([0x0001, 0x0002], undefined, {multicastInterface:'192.168.0.2'});
+server.on('listening', function() {
+  console.log('server listening on interface %s, port %d, universes %j', this.multicastInterface, this.port, this.universes);
 });
 server.on('packet', function (packet) {
   var sourceName = packet.getSourceName();

--- a/lib/client.js
+++ b/lib/client.js
@@ -24,10 +24,15 @@ var dgram = require('dgram');
 var e131 = require('./e131');
 
 // E1.31 client object constructor
-function Client(arg, port) {
+function Client(arg, port, options) {
   if (this instanceof Client === false) {
     return new Client(arg, port);
   }
+
+  const default_options = {
+    multicastInterface: '0.0.0.0'
+  }
+  options = Object.assign({}, default_options, options)
 
   if (arg === undefined) {
     throw new TypeError('arg should be a host address, name or universe');
@@ -36,6 +41,10 @@ function Client(arg, port) {
   this.host = Number.isInteger(arg) ? e131.getMulticastGroup(arg) : arg;
   this.port = port || e131.DEFAULT_PORT;
   this._socket = dgram.createSocket('udp4');
+
+  this._socket.bind(port, () => {
+    this._socket.setMulticastInterface(options.multicastInterface);
+  });
 }
 
 // create a new E1.31 packet

--- a/lib/server.js
+++ b/lib/server.js
@@ -26,17 +26,23 @@ var EventEmitter = require('events').EventEmitter;
 var e131 = require('./e131');
 
 // E1.31 server object constructor
-function Server(universes, port) {
+function Server(universes, port, options) {
   if (this instanceof Server === false) {
     return new Server(port);
   }
   EventEmitter.call(this);
+
+  const default_options = {
+    multicastInterface: undefined
+  }
+  options = Object.assign({}, default_options, options);
 
   if (universes !== undefined && !Array.isArray(universes)) {
     universes = [universes];
   }
   this.universes = universes || [0x01];
   this.port = port || e131.DEFAULT_PORT;
+  this.multicastInterface = options.multicastInterface;
   this._socket = dgram.createSocket('udp4');
   this._lastSequenceNumber = {};
 
@@ -67,10 +73,15 @@ function Server(universes, port) {
     }
     self._lastSequenceNumber[packet.getUniverse()] = packet.getSequenceNumber();
   });
-  this._socket.bind(this.port, function onListening() {
+  this._socket.bind(this.port, this.multicastInterface, function onListening() {
     self.universes.forEach(function (universe) {
       var multicastGroup = e131.getMulticastGroup(universe);
-      self._socket.addMembership(multicastGroup);
+
+      if (self.multicastInterface === undefined) {
+        self._socket.addMembership(multicastGroup);
+      } else {
+        self._socket.addMembership(multicastGroup, self.multicastInterface);
+      };
     });
   });
 }


### PR DESCRIPTION
- Adds options object to client and server to make it more easy to add properties in the future
- Client can now specify which outgoing interface is used to send the multicast
- Server can specify which interface joins multicast groups and listens to sACN packets